### PR TITLE
Fix typo in index

### DIFF
--- a/index.md
+++ b/index.md
@@ -7,7 +7,7 @@ Hi, it's me, Russell Johnston. Here are some things I'm currently working on:
 
 * [Dejavu](https://dejavu.abubalay.com/) is a reimplementation of classic versions of [Game Maker](https://www.yoyogames.com/gamemaker) for fun and preservation. A previous attempt, built on LLVM, lives [here](https://github.com/rpjohnst/dejavu-llvm).
 * [Visual Studio C++](https://www.visualstudio.com/vs/features/cplusplus/). At Microsoft, I'm on the team that handles IntelliSense (autocomplete, navigation, etc.).
-* [The Rust programming lanugage](https://www.rust-lang.org/) is a competitor to C and C++ with compile-time memory safety, an ML-like type system, and an excellent community.
+* [The Rust programming language](https://www.rust-lang.org/) is a competitor to C and C++ with compile-time memory safety, an ML-like type system, and an excellent community.
 
 Here are some projects I've been involved with in the past:
 


### PR DESCRIPTION
This PR fixes a typo in `index.md`, namely `lanugage->language`.

Cheers